### PR TITLE
fix api.logger

### DIFF
--- a/tqsdk/api.py
+++ b/tqsdk/api.py
@@ -93,14 +93,15 @@ class TqApi(object):
         self.account_id = account if isinstance(account, str) else account.account_id
         self.logger = logging.getLogger("TqApi")  # 调试信息输出
         if debug:
-            self.logger.setLevel(logging.DEBUG)
-            sh = logging.StreamHandler()
-            sh.setLevel(logging.INFO)
-            sh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-            self.logger.addHandler(sh)
-            fh = logging.FileHandler(filename=debug)
-            fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-            self.logger.addHandler(fh)
+            if not self.logger.handlers:
+                self.logger.setLevel(logging.DEBUG)
+                sh = logging.StreamHandler()
+                sh.setLevel(logging.INFO)
+                sh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+                self.logger.addHandler(sh)
+                fh = logging.FileHandler(filename=debug)
+                fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+                self.logger.addHandler(fh)
         self.send_chan, self.recv_chan = TqChan(self), TqChan(self)  # 消息收发队列
         self.data = {"_path": [], "_listener": set()}  # 数据存储
         self.diffs = []  # 自上次wait_update返回后收到更新数据的数组


### PR DESCRIPTION
当tqsdk在进程/线程中驻留，并且TqApi选择输出日志时，
一旦出现多次登录、登录失败重复登录等情况时，logging.StreamHandler()将被重复添加至self.logger，最终导致——日志重复多次输出，每重复添加一次StreamHandler，相同日志将多增加1条。
例如：
下方日志中以空行截断几次情形：
`2019-03-11 15:54:32,239 - INFO - 通知: 已经连接到交易前置
2019-03-11 15:54:32,260 - WARNING - 通知: 交易服务器登录失败, CTP:不合法的登录

2019-03-11 15:54:51,574 - INFO - 通知: 已经连接到交易前置
2019-03-11 15:54:51,574 - INFO - 通知: 已经连接到交易前置
2019-03-11 15:54:51,594 - WARNING - 通知: 交易服务器登录失败, CTP:不合法的登录
2019-03-11 15:54:51,594 - WARNING - 通知: 交易服务器登录失败, CTP:不合法的登录

2019-03-11 15:55:06,545 - INFO - 通知: 已经连接到交易前置
2019-03-11 15:55:06,545 - INFO - 通知: 已经连接到交易前置
2019-03-11 15:55:06,545 - INFO - 通知: 已经连接到交易前置
2019-03-11 15:55:06,570 - INFO - 通知: 登录成功
2019-03-11 15:55:06,570 - INFO - 通知: 登录成功
2019-03-11 15:55:06,570 - INFO - 通知: 登录成功`

需要对self.logger.handlers进行判断。

