### PR TITLE
lib: 修正用户对同一合约创建多个TargetPosTask导致调仓动作异常的问题

### DIFF
--- a/tqsdk/lib.py
+++ b/tqsdk/lib.py
@@ -8,17 +8,17 @@ from asyncio import gather
 
 class TargetPosTaskSingleton(type):
     _instances = {}
+
     def __call__(cls, api, symbol, price="ACTIVE", offset_priority="今昨,开", trade_chan=None, *args, **kwargs):
-        k = str(api) + symbol
-        if k not in TargetPosTaskSingleton._instances:
-            TargetPosTaskSingleton._instances[k] = super(TargetPosTaskSingleton, cls).__call__(api, symbol, price, offset_priority, trade_chan, *args, **kwargs)
+        if symbol not in TargetPosTaskSingleton._instances:
+            TargetPosTaskSingleton._instances[symbol] = super(TargetPosTaskSingleton, cls).__call__(api, symbol, price, offset_priority, trade_chan, *args, **kwargs)
         else:
-            instance = TargetPosTaskSingleton._instances[k]
+            instance = TargetPosTaskSingleton._instances[symbol]
             if instance.offset_priority != offset_priority:
                 raise Exception("您试图用不同的 offset_priority 参数创建两个 %s 调仓任务, offset_priority参数原为 %s, 现为 %s" % (symbol, instance.offset_priority, offset_priority))
             if instance.price != price:
                 raise Exception("您试图用不同的 price 参数创建两个 %s 调仓任务, price参数原为 %s, 现为 %s" % (symbol, instance.price, price))
-        return TargetPosTaskSingleton._instances[k]
+        return TargetPosTaskSingleton._instances[symbol]
 
 
 class TargetPosTask(object, metaclass=TargetPosTaskSingleton):


### PR DESCRIPTION
本次修改将TargetPosTask修改为每个api中只能为每个合约创建一个TargetPosTask实例, 以避免误用问题发生. 如果用户尝试以相同参数为一个合约多次创建TargetPosTask实例, 只有第一次会真正创建, 后续调用会返回第一次创建的实例. 如果用户尝试以不同参数为一个合约多次创建TargetPosTask实例, 会抛出 Exception.

Resolves: #207