### PR TITLE
修复actions ci脚本日志上传失败的问题

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -54,18 +54,23 @@ jobs:
         echo "::set-output name=log_archive_path::./log_archive/"
 
     - name: Run Test Case
+      timeout-minutes: 60
       run: |
         mkdir -p ${{steps.log_info.outputs.log_archive_path}}
         python -W ignore::DeprecationWarning -m pytest --no-print-logs \
           --log-level=DEBUG \
           --log-file=${{steps.log_info.outputs.log_name}}.log
+
+    - name: Zip test log
+      if: always()
+      run: |
         zip-files -o ${{steps.log_info.outputs.log_archive_path}}${{steps.log_info.outputs.log_name}}.zip ./${{steps.log_info.outputs.log_name}}.log
 
     - name: Upload log to artifact
       if: always()
       uses: actions/upload-artifact@v1
       with:
-        name: ${{steps.log_info.outputs.log_name}}.zip
+        name: ${{steps.log_info.outputs.log_name}}
         path: ${{steps.log_info.outputs.log_archive_path}}
 
     - name: build Wheel on Linux Platform

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -40,16 +40,21 @@ jobs:
         echo "::set-output name=log_archive_path::./log_archive/"
 
     - name: Run Test Case
+      timeout-minutes: 60
       run: |
         mkdir -p ${{steps.log_info.outputs.log_archive_path}}
         python -W ignore::DeprecationWarning -m pytest --no-print-logs \
           --log-level=DEBUG \
           --log-file=${{steps.log_info.outputs.log_name}}.log
+
+    - name: Zip test log
+      if: always()
+      run: |
         zip-files -o ${{steps.log_info.outputs.log_archive_path}}${{steps.log_info.outputs.log_name}}.zip ./${{steps.log_info.outputs.log_name}}.log
 
     - name: Upload log to artifact
       if: always()
       uses: actions/upload-artifact@v1
       with:
-        name: ${{steps.log_info.outputs.log_name}}.zip
+        name: ${{steps.log_info.outputs.log_name}}
         path: ${{steps.log_info.outputs.log_archive_path}}

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -40,16 +40,21 @@ jobs:
         echo "::set-output name=log_archive_path::./log_archive/"
 
     - name: Run Test Case
+      timeout-minutes: 60
       run: |
         mkdir -p ${{steps.log_info.outputs.log_archive_path}}
         python -W ignore::DeprecationWarning -m pytest --no-print-logs `
           --log-level=DEBUG `
           --log-file=${{steps.log_info.outputs.log_name}}.log
+          
+    - name: Zip test log
+      if: always()
+      run: |
         zip-files -o ${{steps.log_info.outputs.log_archive_path}}${{steps.log_info.outputs.log_name}}.zip ./${{steps.log_info.outputs.log_name}}.log
 
     - name: Upload log to artifact
       if: always()
       uses: actions/upload-artifact@v1
       with:
-        name: ${{steps.log_info.outputs.log_name}}.zip
+        name: ${{steps.log_info.outputs.log_name}}
         path: ${{steps.log_info.outputs.log_archive_path}}


### PR DESCRIPTION
当集成测试执行失败时，会导致日志压缩失败，继而导致日志上传失败；通过将压缩日志流程单独处理解决该问题。