### PR TITLE
chore: 修复CI脚本输出中文编码格式问题

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -18,6 +18,7 @@ jobs:
         python-arch: ["x64"]
 
     env:
+        PYTHONIOENCODING: "utf-8"
         PYTHONHASHSEED: 32
         TZ: 'Asia/Shanghai'
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -18,6 +18,7 @@ jobs:
         python-arch: ["x64"]
 
     env:
+      PYTHONIOENCODING: "utf-8"
       PYTHONHASHSEED: 32
       TZ: 'Asia/Shanghai'
 

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -18,6 +18,7 @@ jobs:
         python-arch: ["x86", "x64"]
 
     env:
+      PYTHONIOENCODING: "utf-8"
       PYTHONHASHSEED: 32
       TZ: "CST-8"
 


### PR DESCRIPTION
1. 增加 `PYTHONIOENCODING: "utf-8"` 指定python运行环境编码格式，参考：
https://github.com/pytest-dev/pytest/issues/3640