### PR TITLE
默认打开日志 [BE-218] [BE-220]

### DIFF
--- a/design/default_debug_on.md
+++ b/design/default_debug_on.md
@@ -1,0 +1,45 @@
+# 目的：
+
+优化问题排查流程 https://shinnytech.atlassian.net/browse/BE-218
+
+# todo：
+
+* 默认的日志文件夹位置 `os.path.join(os.path.expanduser('~'), ".tqsdk/logs")`
+
+* 日志文件名
+    + 用户 debug=False 指定关闭日志；debug=True 使用默认生成的日志文件；debug=“path_of_file” 指定日志文件
+    + 默认 `datetime('%Y%m%d%H%M%S%f')-{os.getpid()}.log` example: `20200520101101217523-2.log`
+    
+* debug 默认值是 None；(在 setup_connection 添加 filehandler，不需要特别处理 tqwebhelper 了)
+
+```
+log_path = ""  # 日志存放文件
+if debug is None:
+    log_path = _defalut_log_file if isinstance(account, TqAccount) else ""
+if debug is True or isinstance(debug, str):
+    log_path = debug if isinstance(debug, str) else _defalut_log_file 
+```
+
+* 统一日志打印的 format
+    + 实盘 `'%(asctime)s - %(levelname)6s - %(message)s'`
+    + 回测 / 复盘 `'%(levelname)6s - %(message)s'`
+
+* 第一条日志打印 tqsdk 版本号
+
+* api.close()  时删除最后修改时间是 N 天前的日志, 提供环境变量 TQSDK_LOG_SAVED_DAYS 用户可以设置 N，默认 30
+
+* 日志添加对外接口的调用，调用函数名+参数
+    + 增加的原则是所有用户能调到并可能产生副作用的函数
+    + api.xxx 中用户接口一定需要添加 ，lib 里的 set_target_volume
+    + ta / tafunc 不添加，纯算法库
+
+* 需要限制日志文件大小吗？
+    + 不需要，理由：实盘没有 backtest/sim，日志不会一下子就几十上百M，实盘用户应该每天重启策略，策略重启是一定会创建新的日志文件
+
+* 多进程同时写日志
+    + 日志名称为当前时间+进程id，不同进程日志会记录在不同的文件里
+    + 使用 api.copy() 方法，全部日志都是记录在 master_api._logger 下
+ 
+* 实盘的日志记录中有用户账户信息
+
+fix: #179 #177 

--- a/tqsdk/api.py
+++ b/tqsdk/api.py
@@ -41,6 +41,7 @@ from tqsdk.backtest import TqBacktest, TqReplay
 from tqsdk.channel import TqChan
 from tqsdk.diff import _merge_diff, _get_obj, _is_key_exist
 from tqsdk.entity import Entity
+from tqsdk.log import _get_log_format, _get_log_name, _clear_logs, _traced
 from tqsdk.objs import Quote, Kline, Tick, Account, Position, Order, Trade
 from tqsdk.sim import TqSim
 from tqsdk.tqwebhelper import TqWebHelper
@@ -48,6 +49,7 @@ from tqsdk.utils import _generate_uuid, _quotes_add_night
 from .__version__ import __version__
 
 
+@_traced
 class TqApi(object):
     """
     天勤接口及数据管理类
@@ -142,45 +144,13 @@ class TqApi(object):
         # 初始化 logger
         self._logger = logging.getLogger("TqApi")
         self._logger.setLevel(logging.DEBUG)
-        if not self._logger.handlers:
-            sh = logging.StreamHandler()
-            sh.setLevel(logging.INFO)
-            if backtest:  # 如果回测, 则去除第一个本地时间
-                log_format = logging.Formatter('%(levelname)s - %(message)s')
-            else:
-                log_format = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-            sh.setFormatter(log_format)
-            self._logger.addHandler(sh)
-            if debug:
-                fh = logging.FileHandler(filename=debug)
-                fh.setFormatter(log_format)
-                self._logger.addHandler(fh)
-
+        
         # 记录参数
+        self._debug = debug  # 日志选项
+        self._auth = auth  # 支持用户授权
         self._account = TqSim() if account is None else account
         self._backtest = backtest
         self._stock = False if isinstance(self._backtest, TqReplay) else _stock
-
-        # 支持用户授权
-        self._access_token = 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJobi1MZ3ZwbWlFTTJHZHAtRmlScjV5MUF5MnZrQmpLSFFyQVlnQ0UwR1JjIn0.eyJqdGkiOiIwY2UwOTM2Ny0xYjk2LTQ0NTktOGU2My1hYWM1ZTA3Mjc1ZTIiLCJleHAiOjE2MTU1Mzk1MTQsIm5iZiI6MCwiaWF0IjoxNTg0MDAzNTE0LCJpc3MiOiJodHRwczovL2F1dGguc2hpbm55dGVjaC5jb20vYXV0aC9yZWFsbXMvc2hpbm55dGVjaCIsInN1YiI6IjYzMzJhZmUwLWU5OWQtNDc1OC04MjIzLWY5OTBiN2RmOGY4NSIsInR5cCI6IkJlYXJlciIsImF6cCI6InNoaW5ueV90cSIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjUzYTEyYmNkLTc3M2EtNDcyZC1iZWVlLWZlMmQ1ODAzYjU0YyIsImFjciI6IjEiLCJzY29wZSI6ImF0dHJpYnV0ZXMiLCJncmFudHMiOnsiZmVhdHVyZXMiOlsiY21iIiwiYWR2Il0sImFjY291bnRzIjpbIioiXX19.BmqzmorwITPd2YLP9EbhlIxkTDNTAY-PNPfM9LwOkOc5XJlSK34nHZwW14mmIScYiohhN5iaVtPrPNsohFfPcH-FxhFmmr9M_xIJLDf4zw2ObcZwVGTQFnIExjdpj2ej82bPT0yoBBFoOH3NhFuK0agifE0WOp0lXf2kzQsQncZ-y9djCEuwbuZapNmdVhGsWWGt7gMd9ZJNrmViZifSWkOrpiowIQ4fOPp1L2DJju8QldwHtyPnYTZtN56x14Xd7v-4-VB3vWEoHB99r36bjhlXJsxuiZrQom0esahgtV_7gx_G95bN04XevriRXG9JzOSoHhpYQFKqjZlSQ4L7vw'
-        if auth:
-            comma_index = auth.find(',')
-            email, pwd = auth[:comma_index], auth[comma_index + 1:]
-            headers = {
-                "User-Agent": "tqsdk-python %s" % __version__,
-                "Accept": "application/json",
-                "Content-Type": "application/x-www-form-urlencoded"
-            }
-            response = requests.post("https://auth.shinnytech.com/auth/realms/shinnytech/protocol/openid-connect/token",
-                                     headers=headers,
-                                     data="grant_type=password&username=%s&password=%s&client_id=shinny_tq&client_secret=be30b9f4-6862-488a-99ad-21bde0400081" % (email, pwd),
-                                     timeout=30)
-            if response.status_code == 200:
-                self._access_token = json.loads(response.content)["access_token"]
-                self._logger.info("用户权限认证成功")
-            else:
-                self._logger.warning("用户权限认证失败 (%d,%s)" % (response.status_code, response.content))
-
         self._ins_url = os.getenv("TQ_INS_URL", "https://openmd.shinnytech.com/t/md/symbols/latest.json")
         self._md_url = os.getenv("TQ_MD_URL", "ws://nfmd.shinnytech.com/t/nfmd/front/mobile" if self._stock else "wss://openmd.shinnytech.com/t/md/front/mobile")
         self._td_url = os.getenv("TQ_TD_URL", None)
@@ -300,6 +270,7 @@ class TqApi(object):
             self._run_once()
         self._loop.run_until_complete(self._loop.shutdown_asyncgens())
         self._loop.close()
+        _clear_logs()  # 清除过期日志文件
 
     def __enter__(self):
         return self
@@ -1152,9 +1123,46 @@ class TqApi(object):
         self._event_rev += 1
         return org_call_soon(callback, *args, **kargs)
 
+    def _auth_account(self):
+        self._access_token = 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJobi1MZ3ZwbWlFTTJHZHAtRmlScjV5MUF5MnZrQmpLSFFyQVlnQ0UwR1JjIn0.eyJqdGkiOiIwY2UwOTM2Ny0xYjk2LTQ0NTktOGU2My1hYWM1ZTA3Mjc1ZTIiLCJleHAiOjE2MTU1Mzk1MTQsIm5iZiI6MCwiaWF0IjoxNTg0MDAzNTE0LCJpc3MiOiJodHRwczovL2F1dGguc2hpbm55dGVjaC5jb20vYXV0aC9yZWFsbXMvc2hpbm55dGVjaCIsInN1YiI6IjYzMzJhZmUwLWU5OWQtNDc1OC04MjIzLWY5OTBiN2RmOGY4NSIsInR5cCI6IkJlYXJlciIsImF6cCI6InNoaW5ueV90cSIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjUzYTEyYmNkLTc3M2EtNDcyZC1iZWVlLWZlMmQ1ODAzYjU0YyIsImFjciI6IjEiLCJzY29wZSI6ImF0dHJpYnV0ZXMiLCJncmFudHMiOnsiZmVhdHVyZXMiOlsiY21iIiwiYWR2Il0sImFjY291bnRzIjpbIioiXX19.BmqzmorwITPd2YLP9EbhlIxkTDNTAY-PNPfM9LwOkOc5XJlSK34nHZwW14mmIScYiohhN5iaVtPrPNsohFfPcH-FxhFmmr9M_xIJLDf4zw2ObcZwVGTQFnIExjdpj2ej82bPT0yoBBFoOH3NhFuK0agifE0WOp0lXf2kzQsQncZ-y9djCEuwbuZapNmdVhGsWWGt7gMd9ZJNrmViZifSWkOrpiowIQ4fOPp1L2DJju8QldwHtyPnYTZtN56x14Xd7v-4-VB3vWEoHB99r36bjhlXJsxuiZrQom0esahgtV_7gx_G95bN04XevriRXG9JzOSoHhpYQFKqjZlSQ4L7vw'
+        if self._auth:
+            comma_index = self._auth.find(',')
+            email, pwd = self._auth[:comma_index], self._auth[comma_index + 1:]
+            headers = {
+                "User-Agent": "tqsdk-python %s" % __version__,
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded"
+            }
+            response = requests.post("https://auth.shinnytech.com/auth/realms/shinnytech/protocol/openid-connect/token",
+                                     headers=headers,
+                                     data="grant_type=password&username=%s&password=%s&client_id=shinny_tq&client_secret=be30b9f4-6862-488a-99ad-21bde0400081" % (
+                                     email, pwd),
+                                     timeout=30)
+            if response.status_code == 200:
+                self._access_token = json.loads(response.content)["access_token"]
+                self._logger.info("用户权限认证成功")
+            else:
+                self._logger.warning("用户权限认证失败 (%d,%s)" % (response.status_code, response.content))
+
+
     def _setup_connection(self):
         """初始化"""
         tq_web_helper = TqWebHelper(self)
+
+        # TqWebHelper 初始化可能会修改 self._account、self._backtest，所以在这里才初始化 logger
+        # 在此之前使用 self._logger 不会打印日志
+        if not self._logger.handlers:
+            log_format = _get_log_format(self._backtest)
+            sh = logging.StreamHandler()
+            sh.setLevel(logging.INFO)
+            sh.setFormatter(log_format)
+            self._logger.addHandler(sh)
+            if isinstance(self._account, TqAccount) and self._debug is not False or self._debug:
+                log_name = self._debug if isinstance(self._debug, str) else _get_log_name()
+                fh = logging.FileHandler(filename=log_name)
+                fh.setFormatter(log_format)
+                self._logger.addHandler(fh)
+        self._auth_account()  # 支持用户授权
 
         # 等待复盘服务器启动
         if isinstance(self._backtest, TqReplay):

--- a/tqsdk/api.py
+++ b/tqsdk/api.py
@@ -1162,6 +1162,7 @@ class TqApi(object):
                 fh = logging.FileHandler(filename=log_name)
                 fh.setFormatter(log_format)
                 self._logger.addHandler(fh)
+        self._logger.debug(f"tqsdk-python version: {__version__}")
         self._auth_account()  # 支持用户授权
 
         # 等待复盘服务器启动

--- a/tqsdk/backtest.py
+++ b/tqsdk/backtest.py
@@ -253,7 +253,7 @@ class TqBacktest(object):
                 }
                 self._diffs = []
                 self._pending_peek = False
-                self._logger.debug("backtest message send: %s", rtn_data)
+                self._logger.debug("TqBacktest message send: %s", rtn_data)
                 await self._sim_recv_chan.send(rtn_data)
 
     async def _ensure_serial(self, ins, dur):

--- a/tqsdk/lib.py
+++ b/tqsdk/lib.py
@@ -10,6 +10,7 @@ from tqsdk.api import TqApi
 from tqsdk.channel import TqChan
 from tqsdk.datetime import _is_in_trading_time
 from tqsdk.utils import _generate_uuid
+from tqsdk.log import _traced
 
 
 class TargetPosTaskSingleton(type):
@@ -31,6 +32,7 @@ class TargetPosTaskSingleton(type):
         return TargetPosTaskSingleton._instances[symbol]
 
 
+@_traced
 class TargetPosTask(object, metaclass=TargetPosTaskSingleton):
     """目标持仓 task, 该 task 可以将指定合约调整到目标头寸"""
 

--- a/tqsdk/log.py
+++ b/tqsdk/log.py
@@ -116,6 +116,8 @@ def _make_traceable_staticmethod(method_descriptor, class_name=None):
 
 class _FunctionTracingProxy(object):
 
+    _logger = logging.getLogger("TqApi.Trace")
+
     def __init__(self, function, class_name=None):
         """
         :arg function: the function being traced
@@ -133,8 +135,8 @@ class _FunctionTracingProxy(object):
            the value returned by calling *function* with positional
            arguments *args* and keyword arguments *keywords*
         """
-        logging.getLogger("TqApi").handle(logging.LogRecord(
-            "TqApi",  # name
+        self._logger.handle(logging.LogRecord(
+            self._logger.name,  # name
             logging.DEBUG,  # level
             self._func_filename,  # pathname
             self._func_lineno,  # lineno
@@ -143,8 +145,8 @@ class _FunctionTracingProxy(object):
             None,  # exc_info
         ))
         value = function(*args, **keywords)
-        logging.getLogger("TqApi").handle(logging.LogRecord(
-            "TqApi",
+        self._logger.handle(logging.LogRecord(
+            self._logger.name,
             logging.DEBUG,
             self._func_filename,
             self._func_lineno,

--- a/tqsdk/log.py
+++ b/tqsdk/log.py
@@ -1,0 +1,152 @@
+# !usr/bin/env python3
+# -*- coding:utf-8 -*-
+__author__ = 'yanqiong'
+
+import datetime
+import logging
+import os
+import warnings
+from functools import wraps
+from inspect import isclass, isroutine
+from types import FunctionType
+
+from .__version__ import __version__
+
+DEBUG_DIR = os.path.join(os.path.expanduser('~'), ".tqsdk/logs")
+
+
+def _get_log_format(is_backtest=None):
+    """返回日志格式"""
+    if is_backtest:
+        return logging.Formatter(f'%(levelname)6s - %(message)s')
+    else:
+        return logging.Formatter(f'%(asctime)s - %(levelname)6s - %(message)s')
+
+
+def _get_log_name():
+    """返回默认 debug 文件生成的位置"""
+    if not os.path.exists(DEBUG_DIR):
+        os.makedirs(os.path.join(os.path.expanduser('~'), ".tqsdk/logs"), exist_ok=True)
+    return os.path.join(DEBUG_DIR, f"{datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')}-{os.getpid()}.log")
+
+
+def _clear_logs():
+    """清除最后修改时间是 n 天前的日志"""
+    if not os.path.exists(DEBUG_DIR):
+        return
+    n = os.getenv("TQ_SAVE_LOG_DAYS", 30)
+    dt = datetime.datetime.now() - datetime.timedelta(days=int(n))
+    for log in os.listdir(DEBUG_DIR):
+        path = os.path.join(DEBUG_DIR, log)
+        if datetime.datetime.fromtimestamp(os.stat(path).st_mtime) < dt:
+            os.remove(path)
+
+
+def _traced(*args):
+    obj = args[0] if args else None
+    if obj is None:  # treat `@_traced()' as equivalent to `@_traced'
+        return _traced
+    if isclass(obj):  # `@_traced' class
+        return _install_traceable_methods(obj)
+    elif isroutine(obj):  # `@_traced' function
+        return _make_traceable_function(obj)
+
+
+def _install_traceable_methods(class_):
+    traceable_method_names = []
+    for (name, member) in class_.__dict__.items():
+        if isroutine(member) and (not name.startswith("_") or name == "__init__"):
+            traceable_method_names.append(name)
+
+    # replace each named method with a tracing proxy method
+    for method_name in traceable_method_names:
+        descriptor = class_.__dict__[method_name]
+        descriptor_type = type(descriptor)
+
+        if descriptor_type is FunctionType:
+            tracing_proxy_descriptor = _make_traceable_instancemethod(descriptor, class_.__name__)
+        elif descriptor_type is classmethod:
+            tracing_proxy_descriptor = _make_traceable_classmethod(descriptor, class_.__name__)
+        elif descriptor_type is staticmethod:
+            tracing_proxy_descriptor = _make_traceable_staticmethod(descriptor, class_.__name__)
+        else:
+            # should be unreachable, but issue a warning just in case
+            warnings.warn("tracing not supported for %r" % descriptor_type)
+            continue
+
+        # class_.__dict__ is a mapping proxy; direct assignment not supported
+        setattr(class_, method_name, tracing_proxy_descriptor)
+
+    return class_
+
+
+def _make_traceable_function(function, class_name=None):
+    @wraps(function)
+    def traced_function_delegator(*args, **keywords):
+        return traced_function_delegator._proxy(function, args, keywords)
+    traced_function_delegator._proxy = _FunctionTracingProxy(function, class_name)
+    return traced_function_delegator
+
+
+def _make_traceable_instancemethod(unbound_function, class_name=None):
+    @wraps(unbound_function)
+    def traced_instancemethod_delegator(self_, *args, **keywords):
+        method = unbound_function.__get__(self_, self_.__class__)
+        return traced_instancemethod_delegator._proxy(method, args, keywords)
+    traced_instancemethod_delegator._proxy = _FunctionTracingProxy(unbound_function, class_name)
+    return traced_instancemethod_delegator
+
+
+def _make_traceable_classmethod(method_descriptor, class_name=None):
+    function = method_descriptor.__func__
+    @wraps(function)
+    def traced_classmethod_delegator(cls, *args, **keywords):
+        method = method_descriptor.__get__(None, cls)
+        return traced_classmethod_delegator._proxy(method, args, keywords)
+    traced_classmethod_delegator._proxy = _FunctionTracingProxy(function, class_name)
+    return classmethod(traced_classmethod_delegator)
+
+
+def _make_traceable_staticmethod(method_descriptor, class_name=None):
+    return staticmethod(_make_traceable_function(method_descriptor.__func__, class_name))
+
+
+class _FunctionTracingProxy(object):
+
+    def __init__(self, function, class_name=None):
+        """
+        :arg function: the function being traced
+        """
+        func_code = function.__code__
+        self._func_filename = func_code.co_filename
+        self._func_lineno = func_code.co_firstlineno
+        self._func_name = f"{(class_name + '.') if class_name else ''}{function.__name__}"
+
+    def __call__(self, function, args, keywords):
+        """Call *function*, tracing its arguments and return value.
+        :arg tuple args: the positional arguments for *function*
+        :arg dict keywords: the keyword arguments for *function*
+        :return:
+           the value returned by calling *function* with positional
+           arguments *args* and keyword arguments *keywords*
+        """
+        logging.getLogger("TqApi").handle(logging.LogRecord(
+            "TqApi",  # name
+            logging.DEBUG,  # level
+            self._func_filename,  # pathname
+            self._func_lineno,  # lineno
+            "%s CALL *%r **%r",  # msg
+            (self._func_name, args, keywords),  # args
+            None,  # exc_info
+        ))
+        value = function(*args, **keywords)
+        logging.getLogger("TqApi").handle(logging.LogRecord(
+            "TqApi",
+            logging.DEBUG,
+            self._func_filename,
+            self._func_lineno,
+            "%s RETURN %r",
+            (self._func_name, value),
+            None,
+        ))
+        return value

--- a/tqsdk/log.py
+++ b/tqsdk/log.py
@@ -38,8 +38,11 @@ def _clear_logs():
     dt = datetime.datetime.now() - datetime.timedelta(days=int(n))
     for log in os.listdir(DEBUG_DIR):
         path = os.path.join(DEBUG_DIR, log)
-        if datetime.datetime.fromtimestamp(os.stat(path).st_mtime) < dt:
-            os.remove(path)
+        try:
+            if datetime.datetime.fromtimestamp(os.stat(path).st_mtime) < dt:
+                os.remove(path)
+        except:
+            pass  # 忽略抛错
 
 
 def _traced(*args):


### PR DESCRIPTION
### 目的：

优化问题排查流程 https://shinnytech.atlassian.net/browse/BE-218

### todo：

* 默认的日志文件夹位置 `os.path.join(os.path.expanduser('~'), ".tqsdk/logs")`
* 日志文件名
    + 用户 debug=False 指定关闭日志；debug=True 使用默认生成的日志文件；debug=“path_of_file” 指定日志文件
    + 默认 `datetime('%Y%m%d%H%M%S%f')-{os.getpid()}.log` example: `20200520101101217523-2.log`
* debug 默认值是 None；(在 setup_connection 添加 filehandler，不需要特别处理 tqwebhelper 了)
```
log_path = ""  # 日志存放文件
if debug is None:
    log_path = _defalut_log_file if isinstance(account, TqAccount) else ""
if debug is True or isinstance(debug, str):
    log_path = debug if isinstance(debug, str) else _defalut_log_file 
```
* 统一日志打印的 format
    + 实盘 `'%(asctime)s - %(levelname)6s - %(message)s'`
    + 回测 / 复盘 `'%(levelname)6s - %(message)s'`
* api.close()  时删除最后修改时间是 N 天前的日志, 提供环境变量 TQSDK_LOG_SAVED_DAYS 用户可以设置 N，默认 30
* 日志添加对外接口的调用，调用函数名+参数，返回值需要打印日志？
    + api.xxx 中用户接口一定需要添加 ，lib 里的 set_target_volume
    + ta / tafunc 不添加
* 需要限制日志文件大小吗？如果限制的话，多大合适？
    + 不需要，理由：实盘没有 backtest/sim，日志不会一下子就几十上百M，实盘用户应该每天重启策略，策略重启是一定会创建新的日志文件
* 多进程同时写日志
    + 日志名以当前时间开头，不同进程日志自然会记录在不同的文件里
    + 使用 api.copy() 方法，全部日志都是记录在 master_api._logger 下
* 实盘的日志记录中有用户账户信息

fix: #179 #177 
