### PR TITLE
日志中取消打印公开函数调用

### DIFF
--- a/tqsdk/api.py
+++ b/tqsdk/api.py
@@ -41,7 +41,7 @@ from tqsdk.backtest import TqBacktest, TqReplay
 from tqsdk.channel import TqChan
 from tqsdk.diff import _merge_diff, _get_obj, _is_key_exist, _register_update_chan
 from tqsdk.entity import Entity
-from tqsdk.log import _get_log_format, _get_log_name, _clear_logs, _traced
+from tqsdk.log import _get_log_format, _get_log_name, _clear_logs, _fun_traced
 from tqsdk.objs import Quote, Kline, Tick, Account, Position, Order, Trade
 from tqsdk.sim import TqSim
 from tqsdk.tqwebhelper import TqWebHelper
@@ -49,7 +49,6 @@ from tqsdk.utils import _generate_uuid, _quotes_add_night
 from .__version__ import __version__
 
 
-@_traced
 class TqApi(object):
     """
     天勤接口及数据管理类
@@ -57,6 +56,7 @@ class TqApi(object):
     通常情况下, 一个线程中 **应该只有一个** TqApi的实例, 它负责维护网络连接, 接收行情及账户数据, 并在内存中维护业务数据截面
     """
 
+    @_fun_traced
     def __init__(self, account: Union[TqAccount, TqSim, None] = None, auth: Optional[str] = None, url: Optional[str] = None,
                  backtest: Union[TqBacktest, TqReplay, None] = None, web_gui: [bool, str] = False, debug: Optional[str] = None,
                  loop: Optional[asyncio.AbstractEventLoop] = None, _stock: bool = False, _ins_url=None, _md_url=None, _td_url=None) -> None:
@@ -225,6 +225,7 @@ class TqApi(object):
         self._diffs = [{}]
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def copy(self) -> 'TqApi':
         """
         创建当前TqApi的一个副本. 这个副本可以在另一个线程中使用
@@ -239,6 +240,7 @@ class TqApi(object):
         _merge_diff(slave_api._data, _copy_diff, slave_api._prototype, False)
         return slave_api
 
+    @_fun_traced
     def close(self) -> None:
         """
         关闭天勤接口实例并释放相应资源
@@ -279,6 +281,7 @@ class TqApi(object):
         self.close()
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_quote(self, symbol: str) -> Quote:
         """
         获取指定合约的盘口行情.
@@ -330,6 +333,7 @@ class TqApi(object):
         return quote
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_kline_serial(self, symbol: Union[str, List[str]], duration_seconds: int, data_length: int = 200,
                          chart_id: Optional[str] = None) -> pd.DataFrame:
         """
@@ -468,6 +472,7 @@ class TqApi(object):
         return serial["df"]
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_tick_serial(self, symbol: str, data_length: int = 200, chart_id: Optional[str] = None) -> pd.DataFrame:
         """
         获取tick序列数据
@@ -548,6 +553,7 @@ class TqApi(object):
         return serial["df"]
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def insert_order(self, symbol: str, direction: str, offset: str, volume: int, limit_price: Optional[float] = None,
                      order_id: Optional[str] = None) -> Order:
         """
@@ -638,6 +644,7 @@ class TqApi(object):
         return order
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def cancel_order(self, order_or_order_id: Union[str, Order]) -> None:
         """
         发送撤单指令. **注意: 指令将在下次调用** :py:meth:`~tqsdk.api.TqApi.wait_update` **时发出**
@@ -689,6 +696,7 @@ class TqApi(object):
         self._send_pack(msg)
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_account(self) -> Account:
         """
         获取用户账户资金信息
@@ -715,6 +723,7 @@ class TqApi(object):
                              self._prototype["trade"]["*"]["accounts"]["@"])
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_position(self, symbol: Optional[str] = None) -> Union[Position, Entity]:
         """
         获取用户持仓信息
@@ -755,6 +764,7 @@ class TqApi(object):
         return _get_obj(self._data, ["trade", self._account._account_id, "positions"])
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_order(self, order_id: Optional[str] = None) -> Union[Order, Entity]:
         """
         获取用户委托单信息
@@ -794,6 +804,7 @@ class TqApi(object):
         return _get_obj(self._data, ["trade", self._account._account_id, "orders"])
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def get_trade(self, trade_id: Optional[str] = None) -> Union[Trade, Entity]:
         """
         获取用户成交信息
@@ -817,6 +828,7 @@ class TqApi(object):
         return _get_obj(self._data, ["trade", self._account._account_id, "trades"])
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def wait_update(self, deadline: Optional[float] = None) -> None:
         """
         等待业务数据更新
@@ -894,6 +906,7 @@ class TqApi(object):
             update_task.cancel()
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def is_changing(self, obj: Any, key: Union[str, List[str], None] = None) -> bool:
         """
         判定obj最近是否有更新
@@ -999,6 +1012,7 @@ class TqApi(object):
         return False
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def is_serial_ready(self, obj: pd.DataFrame) -> bool:
         """
         判断是否已经从服务器收到了所有订阅的数据
@@ -1030,6 +1044,7 @@ class TqApi(object):
         return self._serials[id(obj)]["init"]
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def create_task(self, coro: asyncio.coroutine) -> asyncio.Task:
         """
         创建一个task
@@ -1064,6 +1079,7 @@ class TqApi(object):
         return task
 
     # ----------------------------------------------------------------------
+    @_fun_traced
     def register_update_notify(self, obj: Optional[Any] = None, chan: Optional[TqChan] = None) -> TqChan:
         """
         注册一个channel以便接受业务数据更新通知
@@ -1890,6 +1906,7 @@ class TqApi(object):
         else:
             self._master._slave_send_pack(pack)
 
+    @_fun_traced
     def draw_text(self, base_k_dataframe: pd.DataFrame, text: str, x: Optional[int] = None, y: Optional[float] = None,
                   id: Optional[str] = None, board: str = "MAIN", color: Union[str, int] = "red") -> None:
         """
@@ -1934,6 +1951,7 @@ class TqApi(object):
         }
         self._send_chart_data(base_k_dataframe, id, serial)
 
+    @_fun_traced
     def draw_line(self, base_k_dataframe: pd.DataFrame, x1: int, y1: float, x2: int, y2: float,
                   id: Optional[str] = None, board: str = "MAIN", line_type: str = "LINE", color: Union[str, int] = "red",
                   width: int = 1) -> None:
@@ -1977,6 +1995,7 @@ class TqApi(object):
         }
         self._send_chart_data(base_k_dataframe, id, serial)
 
+    @_fun_traced
     def draw_box(self, base_k_dataframe: pd.DataFrame, x1: int, y1: float, x2: int, y2: float, id: Optional[str] = None,
                  board: str = "MAIN", bg_color: Union[str, int] = "black", color: Union[str, int] = "red", width: int = 1) -> None:
         """

--- a/tqsdk/api.py
+++ b/tqsdk/api.py
@@ -41,7 +41,7 @@ from tqsdk.backtest import TqBacktest, TqReplay
 from tqsdk.channel import TqChan
 from tqsdk.diff import _merge_diff, _get_obj, _is_key_exist, _register_update_chan
 from tqsdk.entity import Entity
-from tqsdk.log import _get_log_format, _get_log_name, _clear_logs, _fun_traced
+from tqsdk.log import _get_log_format, _get_log_name, _clear_logs
 from tqsdk.objs import Quote, Kline, Tick, Account, Position, Order, Trade
 from tqsdk.sim import TqSim
 from tqsdk.tqwebhelper import TqWebHelper
@@ -56,7 +56,6 @@ class TqApi(object):
     通常情况下, 一个线程中 **应该只有一个** TqApi的实例, 它负责维护网络连接, 接收行情及账户数据, 并在内存中维护业务数据截面
     """
 
-    @_fun_traced
     def __init__(self, account: Union[TqAccount, TqSim, None] = None, auth: Optional[str] = None, url: Optional[str] = None,
                  backtest: Union[TqBacktest, TqReplay, None] = None, web_gui: [bool, str] = False, debug: Optional[str] = None,
                  loop: Optional[asyncio.AbstractEventLoop] = None, _stock: bool = False, _ins_url=None, _md_url=None, _td_url=None) -> None:
@@ -225,7 +224,6 @@ class TqApi(object):
         self._diffs = [{}]
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def copy(self) -> 'TqApi':
         """
         创建当前TqApi的一个副本. 这个副本可以在另一个线程中使用
@@ -240,7 +238,6 @@ class TqApi(object):
         _merge_diff(slave_api._data, _copy_diff, slave_api._prototype, False)
         return slave_api
 
-    @_fun_traced
     def close(self) -> None:
         """
         关闭天勤接口实例并释放相应资源
@@ -281,7 +278,6 @@ class TqApi(object):
         self.close()
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_quote(self, symbol: str) -> Quote:
         """
         获取指定合约的盘口行情.
@@ -333,7 +329,6 @@ class TqApi(object):
         return quote
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_kline_serial(self, symbol: Union[str, List[str]], duration_seconds: int, data_length: int = 200,
                          chart_id: Optional[str] = None) -> pd.DataFrame:
         """
@@ -472,7 +467,6 @@ class TqApi(object):
         return serial["df"]
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_tick_serial(self, symbol: str, data_length: int = 200, chart_id: Optional[str] = None) -> pd.DataFrame:
         """
         获取tick序列数据
@@ -553,7 +547,6 @@ class TqApi(object):
         return serial["df"]
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def insert_order(self, symbol: str, direction: str, offset: str, volume: int, limit_price: Optional[float] = None,
                      order_id: Optional[str] = None) -> Order:
         """
@@ -644,7 +637,6 @@ class TqApi(object):
         return order
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def cancel_order(self, order_or_order_id: Union[str, Order]) -> None:
         """
         发送撤单指令. **注意: 指令将在下次调用** :py:meth:`~tqsdk.api.TqApi.wait_update` **时发出**
@@ -696,7 +688,6 @@ class TqApi(object):
         self._send_pack(msg)
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_account(self) -> Account:
         """
         获取用户账户资金信息
@@ -723,7 +714,6 @@ class TqApi(object):
                              self._prototype["trade"]["*"]["accounts"]["@"])
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_position(self, symbol: Optional[str] = None) -> Union[Position, Entity]:
         """
         获取用户持仓信息
@@ -764,7 +754,6 @@ class TqApi(object):
         return _get_obj(self._data, ["trade", self._account._account_id, "positions"])
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_order(self, order_id: Optional[str] = None) -> Union[Order, Entity]:
         """
         获取用户委托单信息
@@ -804,7 +793,6 @@ class TqApi(object):
         return _get_obj(self._data, ["trade", self._account._account_id, "orders"])
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def get_trade(self, trade_id: Optional[str] = None) -> Union[Trade, Entity]:
         """
         获取用户成交信息
@@ -828,7 +816,6 @@ class TqApi(object):
         return _get_obj(self._data, ["trade", self._account._account_id, "trades"])
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def wait_update(self, deadline: Optional[float] = None) -> None:
         """
         等待业务数据更新
@@ -906,7 +893,6 @@ class TqApi(object):
             update_task.cancel()
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def is_changing(self, obj: Any, key: Union[str, List[str], None] = None) -> bool:
         """
         判定obj最近是否有更新
@@ -1012,7 +998,6 @@ class TqApi(object):
         return False
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def is_serial_ready(self, obj: pd.DataFrame) -> bool:
         """
         判断是否已经从服务器收到了所有订阅的数据
@@ -1044,7 +1029,6 @@ class TqApi(object):
         return self._serials[id(obj)]["init"]
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def create_task(self, coro: asyncio.coroutine) -> asyncio.Task:
         """
         创建一个task
@@ -1079,7 +1063,6 @@ class TqApi(object):
         return task
 
     # ----------------------------------------------------------------------
-    @_fun_traced
     def register_update_notify(self, obj: Optional[Any] = None, chan: Optional[TqChan] = None) -> TqChan:
         """
         注册一个channel以便接受业务数据更新通知
@@ -1906,7 +1889,6 @@ class TqApi(object):
         else:
             self._master._slave_send_pack(pack)
 
-    @_fun_traced
     def draw_text(self, base_k_dataframe: pd.DataFrame, text: str, x: Optional[int] = None, y: Optional[float] = None,
                   id: Optional[str] = None, board: str = "MAIN", color: Union[str, int] = "red") -> None:
         """
@@ -1951,7 +1933,6 @@ class TqApi(object):
         }
         self._send_chart_data(base_k_dataframe, id, serial)
 
-    @_fun_traced
     def draw_line(self, base_k_dataframe: pd.DataFrame, x1: int, y1: float, x2: int, y2: float,
                   id: Optional[str] = None, board: str = "MAIN", line_type: str = "LINE", color: Union[str, int] = "red",
                   width: int = 1) -> None:
@@ -1995,7 +1976,6 @@ class TqApi(object):
         }
         self._send_chart_data(base_k_dataframe, id, serial)
 
-    @_fun_traced
     def draw_box(self, base_k_dataframe: pd.DataFrame, x1: int, y1: float, x2: int, y2: float, id: Optional[str] = None,
                  board: str = "MAIN", bg_color: Union[str, int] = "black", color: Union[str, int] = "red", width: int = 1) -> None:
         """

--- a/tqsdk/lib.py
+++ b/tqsdk/lib.py
@@ -13,7 +13,7 @@ from tqsdk.channel import TqChan
 from tqsdk.datetime import _is_in_trading_time
 from tqsdk.diff import _get_obj
 from tqsdk.utils import _generate_uuid
-from tqsdk.log import _traced
+from tqsdk.log import _fun_traced
 
 
 class TargetPosTaskSingleton(type):
@@ -35,10 +35,10 @@ class TargetPosTaskSingleton(type):
         return TargetPosTaskSingleton._instances[symbol]
 
 
-@_traced
 class TargetPosTask(object, metaclass=TargetPosTaskSingleton):
     """目标持仓 task, 该 task 可以将指定合约调整到目标头寸"""
 
+    @_fun_traced
     def __init__(self, api: TqApi, symbol: str, price: str = "ACTIVE", offset_priority: str = "今昨,开",
                  trade_chan: Optional[TqChan] = None) -> None:
         """
@@ -92,6 +92,7 @@ class TargetPosTask(object, metaclass=TargetPosTaskSingleton):
         self._local_time_record = time.time() - 0.005  # 更新最新行情时间时的本地时间
         self._local_time_record_update_chan = TqChan(self._api, last_only=True)  # 监听 self._local_time_record 更新
 
+    @_fun_traced
     def set_target_volume(self, volume: int) -> None:
         """
         设置目标持仓手数

--- a/tqsdk/lib.py
+++ b/tqsdk/lib.py
@@ -13,7 +13,6 @@ from tqsdk.channel import TqChan
 from tqsdk.datetime import _is_in_trading_time
 from tqsdk.diff import _get_obj
 from tqsdk.utils import _generate_uuid
-from tqsdk.log import _fun_traced
 
 
 class TargetPosTaskSingleton(type):
@@ -38,7 +37,6 @@ class TargetPosTaskSingleton(type):
 class TargetPosTask(object, metaclass=TargetPosTaskSingleton):
     """目标持仓 task, 该 task 可以将指定合约调整到目标头寸"""
 
-    @_fun_traced
     def __init__(self, api: TqApi, symbol: str, price: str = "ACTIVE", offset_priority: str = "今昨,开",
                  trade_chan: Optional[TqChan] = None) -> None:
         """
@@ -92,7 +90,6 @@ class TargetPosTask(object, metaclass=TargetPosTaskSingleton):
         self._local_time_record = time.time() - 0.005  # 更新最新行情时间时的本地时间
         self._local_time_record_update_chan = TqChan(self._api, last_only=True)  # 监听 self._local_time_record 更新
 
-    @_fun_traced
     def set_target_volume(self, volume: int) -> None:
         """
         设置目标持仓手数

--- a/tqsdk/log.py
+++ b/tqsdk/log.py
@@ -38,14 +38,3 @@ def _clear_logs():
                 os.remove(path)
         except:
             pass  # 忽略抛错
-
-
-def _fun_traced(function):
-    logger = logging.getLogger("TqApi.Trace")
-    @wraps(function)
-    def wrapper(*args, **kwds):
-        logger.debug(f'[{function.__module__}.{function.__name__}] CALL *({args}) **{{{kwds}}}')
-        value = function(*args, **kwds)
-        logger.debug(f'[{function.__module__}.{function.__name__}] RETURN {value}')
-        return value
-    return wrapper

--- a/tqsdk/log.py
+++ b/tqsdk/log.py
@@ -5,12 +5,7 @@ __author__ = 'yanqiong'
 import datetime
 import logging
 import os
-import warnings
 from functools import wraps
-from inspect import isclass, isroutine
-from types import FunctionType
-
-from .__version__ import __version__
 
 DEBUG_DIR = os.path.join(os.path.expanduser('~'), ".tqsdk/logs")
 
@@ -45,113 +40,12 @@ def _clear_logs():
             pass  # 忽略抛错
 
 
-def _traced(*args):
-    obj = args[0] if args else None
-    if obj is None:  # treat `@_traced()' as equivalent to `@_traced'
-        return _traced
-    if isclass(obj):  # `@_traced' class
-        return _install_traceable_methods(obj)
-    elif isroutine(obj):  # `@_traced' function
-        return _make_traceable_function(obj)
-
-
-def _install_traceable_methods(class_):
-    traceable_method_names = []
-    for (name, member) in class_.__dict__.items():
-        if isroutine(member) and (not name.startswith("_") or name == "__init__"):
-            traceable_method_names.append(name)
-
-    # replace each named method with a tracing proxy method
-    for method_name in traceable_method_names:
-        descriptor = class_.__dict__[method_name]
-        descriptor_type = type(descriptor)
-
-        if descriptor_type is FunctionType:
-            tracing_proxy_descriptor = _make_traceable_instancemethod(descriptor, class_.__name__)
-        elif descriptor_type is classmethod:
-            tracing_proxy_descriptor = _make_traceable_classmethod(descriptor, class_.__name__)
-        elif descriptor_type is staticmethod:
-            tracing_proxy_descriptor = _make_traceable_staticmethod(descriptor, class_.__name__)
-        else:
-            # should be unreachable, but issue a warning just in case
-            warnings.warn("tracing not supported for %r" % descriptor_type)
-            continue
-
-        # class_.__dict__ is a mapping proxy; direct assignment not supported
-        setattr(class_, method_name, tracing_proxy_descriptor)
-
-    return class_
-
-
-def _make_traceable_function(function, class_name=None):
+def _fun_traced(function):
+    logger = logging.getLogger("TqApi.Trace")
     @wraps(function)
-    def traced_function_delegator(*args, **keywords):
-        return traced_function_delegator._proxy(function, args, keywords)
-    traced_function_delegator._proxy = _FunctionTracingProxy(function, class_name)
-    return traced_function_delegator
-
-
-def _make_traceable_instancemethod(unbound_function, class_name=None):
-    @wraps(unbound_function)
-    def traced_instancemethod_delegator(self_, *args, **keywords):
-        method = unbound_function.__get__(self_, self_.__class__)
-        return traced_instancemethod_delegator._proxy(method, args, keywords)
-    traced_instancemethod_delegator._proxy = _FunctionTracingProxy(unbound_function, class_name)
-    return traced_instancemethod_delegator
-
-
-def _make_traceable_classmethod(method_descriptor, class_name=None):
-    function = method_descriptor.__func__
-    @wraps(function)
-    def traced_classmethod_delegator(cls, *args, **keywords):
-        method = method_descriptor.__get__(None, cls)
-        return traced_classmethod_delegator._proxy(method, args, keywords)
-    traced_classmethod_delegator._proxy = _FunctionTracingProxy(function, class_name)
-    return classmethod(traced_classmethod_delegator)
-
-
-def _make_traceable_staticmethod(method_descriptor, class_name=None):
-    return staticmethod(_make_traceable_function(method_descriptor.__func__, class_name))
-
-
-class _FunctionTracingProxy(object):
-
-    _logger = logging.getLogger("TqApi.Trace")
-
-    def __init__(self, function, class_name=None):
-        """
-        :arg function: the function being traced
-        """
-        func_code = function.__code__
-        self._func_filename = func_code.co_filename
-        self._func_lineno = func_code.co_firstlineno
-        self._func_name = f"{(class_name + '.') if class_name else ''}{function.__name__}"
-
-    def __call__(self, function, args, keywords):
-        """Call *function*, tracing its arguments and return value.
-        :arg tuple args: the positional arguments for *function*
-        :arg dict keywords: the keyword arguments for *function*
-        :return:
-           the value returned by calling *function* with positional
-           arguments *args* and keyword arguments *keywords*
-        """
-        self._logger.handle(logging.LogRecord(
-            self._logger.name,  # name
-            logging.DEBUG,  # level
-            self._func_filename,  # pathname
-            self._func_lineno,  # lineno
-            "%s CALL *%r **%r",  # msg
-            (self._func_name, args, keywords),  # args
-            None,  # exc_info
-        ))
-        value = function(*args, **keywords)
-        self._logger.handle(logging.LogRecord(
-            self._logger.name,
-            logging.DEBUG,
-            self._func_filename,
-            self._func_lineno,
-            "%s RETURN %r",
-            (self._func_name, value),
-            None,
-        ))
+    def wrapper(*args, **kwds):
+        logger.debug(f'[{function.__module__}.{function.__name__}] CALL *({args}) **{{{kwds}}}')
+        value = function(*args, **kwds)
+        logger.debug(f'[{function.__module__}.{function.__name__}] RETURN {value}')
         return value
+    return wrapper

--- a/tqsdk/test/api/test_backtest.py
+++ b/tqsdk/test/api/test_backtest.py
@@ -3,6 +3,7 @@
 __author__ = 'yanqiong'
 
 import os
+import platform
 import unittest
 import random
 import datetime
@@ -38,7 +39,7 @@ class TestTdBacktest(unittest.TestCase):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         log_path = os.path.join(dir_path, "log_file", "test_backtest.script.lzma")
         times = []
-        for i in range(10):
+        for i in range(1):
             mock = MockServer()
             md_url = "ws://127.0.0.1:5100/"
             td_url = "ws://127.0.0.1:5200/"
@@ -54,7 +55,7 @@ class TestTdBacktest(unittest.TestCase):
                     api.wait_update()
             except BacktestFinished:
                 delta = datetime.datetime.now() - start
-                self.assertLess(delta.seconds, 40)
+                self.assertLess(delta.seconds, 60)
                 times.append(delta.seconds + delta.microseconds * 1e-6)
                 # print(delta.seconds + delta.microseconds * 1e-6)
                 api.close()


### PR DESCRIPTION
性能问题：

### 测试案例1

```
def test():
    start = datetime.datetime.now()
    api = TqApi(debug="a5.log")
    target_pos = TargetPosTask(api, "DCE.m2005")
    for i in range(1000):
        # api._logger.getChild("Test").debug(f"start target_pos.set_target_volume(10) === {i}")
        target_pos.set_target_volume(10)
        # api._logger.getChild("Test").debug(f"end target_pos.set_target_volume(10) === {i}")
    api.close()
    print(datetime.datetime.now() - start)

if __name__ == "__main__":
    test()
```
* 使用 `@traced` 打印日志，运行时间 14s， 日志 20M
* lib 不使用 `@traced`，直接在 `target_pos.set_target_volume(10)` 前后打印两行日志，运行时间 5.6s， 日志 20M

2000行日志，`@traced` 处理的时间为 8s

### 测试案例2
回测一个月，订阅一个合约一分钟K线

* 使用 `@traced` 打印日志，运行时间 825s， 日志 97M
* 使用 `@function_traced` 打印日志，直接添加在公开函数上装饰器，运行时间 680s， 日志 97M
* 不打印函数调用日志，运行时间 30～40s， 日志 74M



