### PR TITLE
修复 pytest 测试内存使用过大的问题

### DIFF
--- a/.github/workflows/ci-linux-py3.6-x64.yml
+++ b/.github/workflows/ci-linux-py3.6-x64.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-linux-py3.7-x64.yml
+++ b/.github/workflows/ci-linux-py3.7-x64.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-linux-py3.8-x64.yml
+++ b/.github/workflows/ci-linux-py3.8-x64.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-macos-py3.6-x64.yml
+++ b/.github/workflows/ci-macos-py3.6-x64.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-macos-py3.7-x64.yml
+++ b/.github/workflows/ci-macos-py3.7-x64.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-macos-py3.8-x64.yml
+++ b/.github/workflows/ci-macos-py3.8-x64.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-win-3.6-x64.yml
+++ b/.github/workflows/ci-win-3.6-x64.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -74,8 +74,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-win-3.6-x86.yml
+++ b/.github/workflows/ci-win-3.6-x86.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -74,8 +74,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-win-3.7-x64.yml
+++ b/.github/workflows/ci-win-3.7-x64.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -74,8 +74,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-win-3.7-x86.yml
+++ b/.github/workflows/ci-win-3.7-x86.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -74,8 +74,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-win-3.8-x64.yml
+++ b/.github/workflows/ci-win-3.8-x64.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -74,8 +74,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/.github/workflows/ci-win-3.8-x86.yml
+++ b/.github/workflows/ci-win-3.8-x86.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         git lfs install
         git lfs pull
-        python -m pip install --upgrade pip wheel setuptools pytest
+        python -m pip install --upgrade pip wheel setuptools pytest pytest-rerunfailures memory_profiler
         python -m pip install -r requirements.txt
 
     - name: Run test case
@@ -74,8 +74,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p ${{ env.TESTLOGPATH }}
-        python -W ignore::DeprecationWarning -m pytest --no-print-logs \
-          --log-level=DEBUG \
+        python -W ignore::DeprecationWarning -m pytest --show-capture=no \
+          --log-level=ERROR \
           --log-file=${{ env.TESTLOGPATH }}${{ env.TESTLOGNAME }}.log
 
     - name: Upload log to artifact

--- a/tqsdk/test/api/helper.py
+++ b/tqsdk/test/api/helper.py
@@ -10,7 +10,6 @@ import asyncio
 import websockets
 from aiohttp import web
 
-
 class MockInsServer():
     def __init__(self, port):
         self.loop = asyncio.new_event_loop()

--- a/tqsdk/test/conftest.py
+++ b/tqsdk/test/conftest.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+__time__ = '2020/6/20 11:45'
+__author__ = 'Hong Yan'
+
+import pytest
+import logging
+from _pytest.logging import LogCaptureHandler
+
+@pytest.fixture(autouse=True)
+def monkey_logging_emit():
+    def mock_emit(self, record: logging.LogRecord) -> None:
+        logging.StreamHandler.emit(self, record)
+    LogCaptureHandler.emit = mock_emit

--- a/tqsdk/test/demo/test_web.py
+++ b/tqsdk/test/demo/test_web.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 import unittest
+import pytest
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
@@ -37,6 +38,7 @@ def run_tianqin_code(port, queue):
     except Exception as e:
         api.close()
 
+@pytest.mark.flaky(reruns=3)
 class WebTestOnChrome(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -69,7 +71,7 @@ class WebTestOnChrome(unittest.TestCase):
     def test_on_macos(self):
         run_for_driver(webdriver.Chrome(options=self.chrome_options), self)
 
-
+@pytest.mark.flaky(reruns=3)
 class WebTestOnFirefox(unittest.TestCase):
 
     def setUp(self) -> None:


### PR DESCRIPTION
调整内容如下：

-  回测时间跨度为 20 个月
-  增加回测内存占用统计，回测过程中，内存占用峰值不超过 1.5GB
-  webtest 测试失败时，尝试 rerun 该用例，最多 rerun 次数为 3 次。