### PR TITLE
修复 TqSDK 文档 readthedocs 构建失败的问题

### DIFF
--- a/.github/workflows/ci-linux-py3.6-x64.yml
+++ b/.github/workflows/ci-linux-py3.6-x64.yml
@@ -125,7 +125,6 @@ jobs:
         git lfs pull
         python -m pip install --upgrade pip wheel setuptools
         python -m pip install -r requirements.txt
-        python -m pip install Sphinx==2.3.1 autodocsumm sphinx_rtd_theme jieba
 
     - name: Build wheel on linux platform
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ simplejson
 selenium
 scipy
 pyjwt
+Sphinx==2.3.1
+autodocsumm
+sphinx_rtd_theme
+jieba


### PR DESCRIPTION
[BE-464] 修复 TqSDK 文档 readthedocs 构建失败的问题
autodocsumm 需要通过 pip 进行安装，原代码中该模块的依赖关系被写在了 CI 脚本中，导致readthedocs 无法正确安装插件，现将该部分依赖改写到 requirement文件中。

[BE-464]: https://shinnytech.atlassian.net/browse/BE-464