### PR TITLE
fix typo

### DIFF
--- a/tqsdk/__init__.py
+++ b/tqsdk/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 name = "tqsdk"

--- a/tqsdk/account.py
+++ b/tqsdk/account.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/algorithm/__init__.py
+++ b/tqsdk/algorithm/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/algorithm/time_table_generater.py
+++ b/tqsdk/algorithm/time_table_generater.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/algorithm/twap.py
+++ b/tqsdk/algorithm/twap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/api.py
+++ b/tqsdk/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 """
 天勤接口的PYTHON封装, 提供以下功能

--- a/tqsdk/backtest.py
+++ b/tqsdk/backtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/backtest/__init__.py
+++ b/tqsdk/backtest/__init__.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/backtest/backtest.py
+++ b/tqsdk/backtest/backtest.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/backtest/replay.py
+++ b/tqsdk/backtest/replay.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/backtest/utils.py
+++ b/tqsdk/backtest/utils.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/baseApi.py
+++ b/tqsdk/baseApi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/baseModule.py
+++ b/tqsdk/baseModule.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/calendar.py
+++ b/tqsdk/calendar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 """
 交易日历处理

--- a/tqsdk/channel.py
+++ b/tqsdk/channel.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/connect.py
+++ b/tqsdk/connect.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/constants.py
+++ b/tqsdk/constants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/data_extension.py
+++ b/tqsdk/data_extension.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/data_series.py
+++ b/tqsdk/data_series.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/datetime.py
+++ b/tqsdk/datetime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 """
 包含有关时间处理的功能函数

--- a/tqsdk/datetime_state.py
+++ b/tqsdk/datetime_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/demo/download_orders.py
+++ b/tqsdk/demo/download_orders.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/demo/example/aberration.py
+++ b/tqsdk/demo/example/aberration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = "Ringo"
 

--- a/tqsdk/demo/example/doublema.py
+++ b/tqsdk/demo/example/doublema.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/dualthrust.py
+++ b/tqsdk/demo/example/dualthrust.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/escalator.py
+++ b/tqsdk/demo/example/escalator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = "Ringo"
 

--- a/tqsdk/demo/example/fairy_four_price.py
+++ b/tqsdk/demo/example/fairy_four_price.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/gridtrading.py
+++ b/tqsdk/demo/example/gridtrading.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/gridtrading_async.py
+++ b/tqsdk/demo/example/gridtrading_async.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/example/momentum.py
+++ b/tqsdk/demo/example/momentum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = "Ringo"
 

--- a/tqsdk/demo/example/random_forest.py
+++ b/tqsdk/demo/example/random_forest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/rbreaker.py
+++ b/tqsdk/demo/example/rbreaker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/turtle.py
+++ b/tqsdk/demo/example/turtle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/example/vwap.py
+++ b/tqsdk/demo/example/vwap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/multiaccount.py
+++ b/tqsdk/demo/multiaccount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'hongyan'
 

--- a/tqsdk/demo/option_tutorial/o10.py
+++ b/tqsdk/demo/option_tutorial/o10.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'ringo'
 

--- a/tqsdk/demo/option_tutorial/o20.py
+++ b/tqsdk/demo/option_tutorial/o20.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'ringo'
 

--- a/tqsdk/demo/option_tutorial/o30.py
+++ b/tqsdk/demo/option_tutorial/o30.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'ringo'
 

--- a/tqsdk/demo/option_tutorial/o40.py
+++ b/tqsdk/demo/option_tutorial/o40.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'ringo'
 

--- a/tqsdk/demo/option_tutorial/o41.py
+++ b/tqsdk/demo/option_tutorial/o41.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'ringo'
 

--- a/tqsdk/demo/ta.py
+++ b/tqsdk/demo/ta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/ta_option.py
+++ b/tqsdk/demo/ta_option.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 #-*- coding:utf-8 -*-
 
 from tqsdk import TqApi, TqAuth, tafunc

--- a/tqsdk/demo/tutorial/backtest.py
+++ b/tqsdk/demo/tutorial/backtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/downloader.py
+++ b/tqsdk/demo/tutorial/downloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/replay.py
+++ b/tqsdk/demo/tutorial/replay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/demo/tutorial/replay2.py
+++ b/tqsdk/demo/tutorial/replay2.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-#-*- coding:utf-8 -*-
-#!/usr/bin/env python
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/replay2.py
+++ b/tqsdk/demo/tutorial/replay2.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 #-*- coding:utf-8 -*-
 #!/usr/bin/env python
 #  -*- coding: utf-8 -*-

--- a/tqsdk/demo/tutorial/t10.py
+++ b/tqsdk/demo/tutorial/t10.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t20.py
+++ b/tqsdk/demo/tutorial/t20.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t30.py
+++ b/tqsdk/demo/tutorial/t30.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t40.py
+++ b/tqsdk/demo/tutorial/t40.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t41.py
+++ b/tqsdk/demo/tutorial/t41.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 
 from tqsdk import TqApi, TqAuth

--- a/tqsdk/demo/tutorial/t50.py
+++ b/tqsdk/demo/tutorial/t50.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t51.py
+++ b/tqsdk/demo/tutorial/t51.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t52.py
+++ b/tqsdk/demo/tutorial/t52.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t53.py
+++ b/tqsdk/demo/tutorial/t53.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t54.py
+++ b/tqsdk/demo/tutorial/t54.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t55.py
+++ b/tqsdk/demo/tutorial/t55.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t56.py
+++ b/tqsdk/demo/tutorial/t56.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t57.py
+++ b/tqsdk/demo/tutorial/t57.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t58.py
+++ b/tqsdk/demo/tutorial/t58.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t59.py
+++ b/tqsdk/demo/tutorial/t59.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chaos'
 

--- a/tqsdk/demo/tutorial/t60.py
+++ b/tqsdk/demo/tutorial/t60.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t70.py
+++ b/tqsdk/demo/tutorial/t70.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t71.py
+++ b/tqsdk/demo/tutorial/t71.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/demo/tutorial/t72.py
+++ b/tqsdk/demo/tutorial/t72.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'ringo'
 

--- a/tqsdk/demo/tutorial/t80.py
+++ b/tqsdk/demo/tutorial/t80.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/demo/tutorial/t90.py
+++ b/tqsdk/demo/tutorial/t90.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/tutorial/t91.py
+++ b/tqsdk/demo/tutorial/t91.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/tutorial/t92.py
+++ b/tqsdk/demo/tutorial/t92.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/tutorial/t93.py
+++ b/tqsdk/demo/tutorial/t93.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/tutorial/t94.py
+++ b/tqsdk/demo/tutorial/t94.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/tutorial/t95.py
+++ b/tqsdk/demo/tutorial/t95.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/demo/tutorial/t96.py
+++ b/tqsdk/demo/tutorial/t96.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/demo/tutorial/underlying_symbol.py
+++ b/tqsdk/demo/tutorial/underlying_symbol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = "Ringo"
 

--- a/tqsdk/diff.py
+++ b/tqsdk/diff.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 #-*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/entity.py
+++ b/tqsdk/entity.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 #-*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/exceptions.py
+++ b/tqsdk/exceptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/ins_schema.py
+++ b/tqsdk/ins_schema.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/lib/__init__.py
+++ b/tqsdk/lib/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/lib/notify.py
+++ b/tqsdk/lib/notify.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/lib/target_pos_scheduler.py
+++ b/tqsdk/lib/target_pos_scheduler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/lib/target_pos_task.py
+++ b/tqsdk/lib/target_pos_task.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/lib/time_table.py
+++ b/tqsdk/lib/time_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/lib/utils.py
+++ b/tqsdk/lib/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/multiaccount.py
+++ b/tqsdk/multiaccount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 __time__ = '2020/8/5 22:45'
 __author__ = 'Hong Yan'

--- a/tqsdk/rangeset.py
+++ b/tqsdk/rangeset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/report.py
+++ b/tqsdk/report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/risk_manager.py
+++ b/tqsdk/risk_manager.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/risk_rule.py
+++ b/tqsdk/risk_rule.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/sim/__init__.py
+++ b/tqsdk/sim/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/sim/trade.py
+++ b/tqsdk/sim/trade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/sim/trade_base.py
+++ b/tqsdk/sim/trade_base.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/sim/utils.py
+++ b/tqsdk/sim/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/sm.py
+++ b/tqsdk/sm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/stockprofit.py
+++ b/tqsdk/stockprofit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 import math
 from tqsdk.entity import Entity

--- a/tqsdk/symbols.py
+++ b/tqsdk/symbols.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/ta.py
+++ b/tqsdk/ta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/tafunc.py
+++ b/tqsdk/tafunc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'limin'
 

--- a/tqsdk/tools/__init__.py
+++ b/tqsdk/tools/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chengzhi'
 

--- a/tqsdk/tools/downloader.py
+++ b/tqsdk/tools/downloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'yangyang'
 

--- a/tqsdk/tqwebhelper.py
+++ b/tqsdk/tqwebhelper.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/trade_extension.py
+++ b/tqsdk/trade_extension.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/tradeable/__init__.py
+++ b/tqsdk/tradeable/__init__.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/interface.py
+++ b/tqsdk/tradeable/interface.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/tradeable/mixin.py
+++ b/tqsdk/tradeable/mixin.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/tradeable/otg/__init__.py
+++ b/tqsdk/tradeable/otg/__init__.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/otg/base_otg.py
+++ b/tqsdk/tradeable/otg/base_otg.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/tradeable/otg/tqaccount.py
+++ b/tqsdk/tradeable/otg/tqaccount.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/tradeable/otg/tqctp.py
+++ b/tqsdk/tradeable/otg/tqctp.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'chenli'
 

--- a/tqsdk/tradeable/otg/tqjees.py
+++ b/tqsdk/tradeable/otg/tqjees.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'chenli'
 

--- a/tqsdk/tradeable/otg/tqkq.py
+++ b/tqsdk/tradeable/otg/tqkq.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/tradeable/otg/tqrohon.py
+++ b/tqsdk/tradeable/otg/tqrohon.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'chenli'
 

--- a/tqsdk/tradeable/otg/tqtradingunit.py
+++ b/tqsdk/tradeable/otg/tqtradingunit.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'chenli'
 

--- a/tqsdk/tradeable/otg/tqyida.py
+++ b/tqsdk/tradeable/otg/tqyida.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'chenli'
 

--- a/tqsdk/tradeable/otg/tqzq.py
+++ b/tqsdk/tradeable/otg/tqzq.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/tradeable/sim/__init__.py
+++ b/tqsdk/tradeable/sim/__init__.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/sim/basesim.py
+++ b/tqsdk/tradeable/sim/basesim.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/sim/tqsim.py
+++ b/tqsdk/tradeable/sim/tqsim.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/sim/tqsim_stock.py
+++ b/tqsdk/tradeable/sim/tqsim_stock.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/sim/trade.py
+++ b/tqsdk/tradeable/sim/trade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/tradeable/sim/trade_base.py
+++ b/tqsdk/tradeable/sim/trade_base.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/tradeable/sim/trade_future.py
+++ b/tqsdk/tradeable/sim/trade_future.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/tradeable/sim/trade_stock.py
+++ b/tqsdk/tradeable/sim/trade_stock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = "mayanqiong"
 

--- a/tqsdk/tradeable/sim/utils.py
+++ b/tqsdk/tradeable/sim/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/tradeable/tradeable.py
+++ b/tqsdk/tradeable/tradeable.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
 __author__ = 'mayanqiong'

--- a/tqsdk/trading_status.py
+++ b/tqsdk/trading_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/utils.py
+++ b/tqsdk/utils.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 __author__ = 'yanqiong'
 

--- a/tqsdk/utils_symbols.py
+++ b/tqsdk/utils_symbols.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'mayanqiong'
 

--- a/tqsdk/zq.py
+++ b/tqsdk/zq.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chenli'
 

--- a/tqsdk/zq_otg.py
+++ b/tqsdk/zq_otg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 __author__ = 'chenli'
 


### PR DESCRIPTION
Hi,

This PR fix the typo of the interpreter path and align the interpreter version to python3.

Also, the duplicate in file "[tqsdk/demo/tutorial/replay2.py]" was removed with commit "unify python interpreter version".
